### PR TITLE
Make sure to return the leased array from the destructor/finalizer

### DIFF
--- a/NCode.ArrayLeases/ArrayLease.cs
+++ b/NCode.ArrayLeases/ArrayLease.cs
@@ -82,7 +82,7 @@ namespace NCode.ArrayLeases
 
     protected virtual void Dispose(bool disposing)
     {
-      if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1 || !disposing) return;
+      if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1) return;
       Return(_array);
     }
 


### PR DESCRIPTION
- There are certain use cases, where deterministic disposal via an explicit call to `Dispose` is hard (say, when the leased object is shared among some threads), hence letting the destuctor to return the leased array can address the aforementioned use cases